### PR TITLE
Filter improvements

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -10,11 +10,13 @@ import (
 	"time"
 )
 
+// Func is a filtering function which is provided two arguments, the os.FileInfo
+// of the considered file, and it's full absolute path.
+type Func func(fi os.FileInfo, path string) bool
+
 // New creates a filesystem that contains everything in source, except files for which
 // ignore returns true.
-//
-// ignore func is provided two arguments, the os.FileInfo of the considered file, and its full absolute path.
-func New(source http.FileSystem, ignore func(fi os.FileInfo, path string) bool) http.FileSystem {
+func New(source http.FileSystem, ignore Func) http.FileSystem {
 	return &filterFS{source: source, ignore: ignore}
 }
 

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -10,11 +10,11 @@ import (
 	"time"
 )
 
-// NewIgnore creates a filesystem that contains everything in source, except files for which
+// New creates a filesystem that contains everything in source, except files for which
 // ignore returns true.
 //
 // ignore func is provided two arguments, the os.FileInfo of the considered file, and its full absolute path.
-func NewIgnore(source http.FileSystem, ignore func(fi os.FileInfo, path string) bool) http.FileSystem {
+func New(source http.FileSystem, ignore func(fi os.FileInfo, path string) bool) http.FileSystem {
 	return &filterFS{source: source, ignore: ignore}
 }
 

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -41,7 +41,7 @@ func Example() {
 			(fi.IsDir() && fi.Name() == "folder-to-skip")
 	}
 
-	fs = filter.NewIgnore(fs, ignore)
+	fs = filter.New(fs, ignore)
 
 	err := vfsutil.Walk(fs, "/", walk)
 	if err != nil {

--- a/filter/parse.go
+++ b/filter/parse.go
@@ -1,0 +1,119 @@
+package filter
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+)
+
+// Parse parses a filter expression string:
+//
+//  `Not(Combine(Extensions(".go"), Extensions(".html")))`
+//
+func Parse(filter string) (Func, error, ast.Node) {
+	expr, err := parser.ParseExpr(filter)
+	if err != nil {
+		return nil, err, nil
+	}
+	return parseExpr(expr)
+}
+
+// parseExpr parses a single call expression.
+func parseExpr(e ast.Expr) (Func, error, ast.Node) {
+	// Validate node is a call expression with an identity.
+	v, ok := e.(*ast.CallExpr)
+	if !ok {
+		return nil, fmt.Errorf("expected call expression"), e
+	}
+	ident, ok := v.Fun.(*ast.Ident)
+	if !ok {
+		return nil, fmt.Errorf("expected ident"), ident
+	}
+
+	// Parse each filter.
+	switch ident.Name {
+	case "Combine":
+		return parseCombine(v, ident)
+	case "Extensions":
+		return parseExtensions(v, ident)
+	case "Not":
+		return parseNot(v, ident)
+	default:
+		return nil, fmt.Errorf("Unknown filter %q", ident.Name), ident
+	}
+}
+
+// parseCombine parses a Combine filter.
+func parseCombine(v *ast.CallExpr, ident *ast.Ident) (Func, error, ast.Node) {
+	// Require at least one argument.
+	if len(v.Args) == 0 {
+		return nil, fmt.Errorf("%q expects at least one argument", ident.Name), ident
+	}
+
+	// Parse each filter argument / call expression and accumulate.
+	var filters []Func
+	for _, arg := range v.Args {
+		filter, err, node := parseExpr(arg)
+		if err != nil {
+			return nil, err, node
+		}
+		filters = append(filters, filter)
+	}
+	return Combine(filters...), nil, nil
+}
+
+// parseExtensions parses a Extensions filter.
+func parseExtensions(v *ast.CallExpr, ident *ast.Ident) (Func, error, ast.Node) {
+	// Require at least one argument.
+	if len(v.Args) == 0 {
+		return nil, fmt.Errorf("%q expects at least one argument", ident.Name), ident
+	}
+
+	// Parse each file extension string literal.
+	var exts []string
+	for _, arg := range v.Args {
+		// Must be a basic literal.
+		s, ok := arg.(*ast.BasicLit)
+		if !ok {
+			return nil, fmt.Errorf("expected string literal"), arg
+		}
+
+		// Must be a string.
+		if s.Kind != token.STRING {
+			return nil, fmt.Errorf("expected string literal"), arg
+		}
+
+		// Must be a non-empty string.
+		if s.Value == "" {
+			return nil, fmt.Errorf("expected filepath extension with leading dot"), arg
+		}
+
+		// Trim the quote prefix/suffix from the value.
+		s.Value = s.Value[1 : len(s.Value)-1]
+
+		// Ensure the extension starts with a dot (.go, .html, etc).
+		if !strings.HasPrefix(s.Value, ".") {
+			fmt.Printf("%q\n", s.Value)
+			return nil, fmt.Errorf("expected filepath extension with leading dot"), arg
+		}
+		exts = append(exts, s.Value)
+	}
+	return Extensions(exts...), nil, nil
+}
+
+// parseNot parses a Not filter.
+func parseNot(v *ast.CallExpr, ident *ast.Ident) (Func, error, ast.Node) {
+	// Require exactly one argument.
+	if len(v.Args) != 1 {
+		return nil, fmt.Errorf("%q expects one argument", ident.Name), ident
+	}
+
+	// Parse filter argument / call expression.
+	filter, err, node := parseExpr(v.Args[0])
+	if err != nil {
+		return nil, err, node
+	}
+	return Not(filter), nil, nil
+}

--- a/filter/util.go
+++ b/filter/util.go
@@ -1,0 +1,47 @@
+package filter
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Extensions returns a filter function that ignores any of the given file
+// extensions.
+func Extensions(exts ...string) Func {
+	return func(fi os.FileInfo, path string) bool {
+		for _, ext := range exts {
+			if filepath.Ext(ext) == ext {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// Not negates the given filter, such that:
+//
+//  Not(Extensions(".go", ".html"))
+//
+// would ignore any file that is not a .go or .html file.
+func Not(filter Func) Func {
+	return func(fi os.FileInfo, path string) bool {
+		return !filter(fi, path)
+	}
+}
+
+// Combine combines multiple filter functions into one. Effectively it is an
+// multiple or operator, that is:
+//
+//  Combine(Extensions(".go"), Extensions(".html"))
+//
+// would ignore both .go and .html files.
+func Combine(filters ...Func) Func {
+	return func(fi os.FileInfo, path string) bool {
+		for _, filter := range filters {
+			if filter(fi, path) {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/filter/util.go
+++ b/filter/util.go
@@ -10,7 +10,7 @@ import (
 func Extensions(exts ...string) Func {
 	return func(fi os.FileInfo, path string) bool {
 		for _, ext := range exts {
-			if filepath.Ext(ext) == ext {
+			if filepath.Ext(path) == ext {
 				return true
 			}
 		}


### PR DESCRIPTION
- Rename `filter.NewIgnore` to `filter.New`.
- Add `filter.Func` for clarity.
- Add utility functions:
  - Add `filter.Extensions` for filtering file extensions.
  - Add `filter.Not` for negating a filter.
  - Add `filter.Combine` for OR'ing multiple filters.
