### PR TITLE
Adjust filter helpers API based on current use cases.

### DIFF
--- a/filter/filters.go
+++ b/filter/filters.go
@@ -5,40 +5,19 @@ import (
 	"path/filepath"
 )
 
-// Extensions returns a filter function that ignores any of the given file
-// extensions.
-func Extensions(exts ...string) Func {
-	return func(path string, _ os.FileInfo) bool {
+// FilesWithExtensions returns a filter that ignores files (but not directories) that
+// have any of the given extensions. For example:
+//
+// 	filter.FilesWithExtensions(".go", ".html")
+//
+// Would ignore both .go and .html files. It would not ignore any directories.
+func FilesWithExtensions(exts ...string) Func {
+	return func(path string, fi os.FileInfo) bool {
+		if fi.IsDir() {
+			return false
+		}
 		for _, ext := range exts {
 			if filepath.Ext(path) == ext {
-				return true
-			}
-		}
-		return false
-	}
-}
-
-// Not negates the given filter, such that:
-//
-// 	Not(Extensions(".go", ".html"))
-//
-// would ignore any file that is not a .go or .html file.
-func Not(filter Func) Func {
-	return func(path string, fi os.FileInfo) bool {
-		return !filter(path, fi)
-	}
-}
-
-// Combine combines multiple filter functions into one. Effectively it is an
-// multiple OR operator, that is:
-//
-// 	Combine(Extensions(".go"), Extensions(".html"))
-//
-// would ignore both .go and .html files.
-func Combine(filters ...Func) Func {
-	return func(path string, fi os.FileInfo) bool {
-		for _, filter := range filters {
-			if filter(path, fi) {
 				return true
 			}
 		}


### PR DESCRIPTION
It seems that providing a specific higher-level API based on real-world needs is better than providing multiple lower-level general APIs. This addresses most common uses and therefore provides most value.

Other filter helpers can be added for future use cases, and for really custom ad-hoc filters, a custom func literal can always be created.