### PR TITLE
Add text/vfstemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Directories
 | [html/vfstemplate](https://godoc.org/github.com/shurcooL/httpfs/html/vfstemplate) | Package vfstemplate offers html/template helpers that use http.FileSystem.                                 |
 | [httputil](https://godoc.org/github.com/shurcooL/httpfs/httputil)                 | Package httputil implements HTTP utility functions for http.FileSystem.                                    |
 | [path/vfspath](https://godoc.org/github.com/shurcooL/httpfs/path/vfspath)         | Package vfspath implements utility routines for manipulating virtual file system paths.                    |
+| [text/vfstemplate](https://godoc.org/github.com/shurcooL/httpfs/text/vfstemplate) | Package vfstemplate offers text/template helpers that use http.FileSystem.                                 |
 | [union](https://godoc.org/github.com/shurcooL/httpfs/union)                       | Package union offers a simple http.FileSystem that can unify multiple filesystems at various mount points. |
 | [vfsutil](https://godoc.org/github.com/shurcooL/httpfs/vfsutil)                   | Package vfsutil implements some I/O utility functions for http.FileSystem.                                 |
 

--- a/text/vfstemplate/vfstemplate.go
+++ b/text/vfstemplate/vfstemplate.go
@@ -1,0 +1,73 @@
+// Package vfstemplate offers text/template helpers that use http.FileSystem.
+package vfstemplate
+
+import (
+	"fmt"
+	"net/http"
+	"path"
+	"text/template"
+
+	"github.com/shurcooL/httpfs/path/vfspath"
+	"github.com/shurcooL/httpfs/vfsutil"
+)
+
+// ParseFiles creates a new Template if t is nil and parses the template definitions from
+// the named files. The returned template's name will have the (base) name and
+// (parsed) contents of the first file. There must be at least one file.
+// If an error occurs, parsing stops and the returned *Template is nil.
+func ParseFiles(fs http.FileSystem, t *template.Template, filenames ...string) (*template.Template, error) {
+	return parseFiles(fs, t, filenames...)
+}
+
+// ParseGlob parses the template definitions in the files identified by the
+// pattern and associates the resulting templates with t. The pattern is
+// processed by vfspath.Glob and must match at least one file. ParseGlob is
+// equivalent to calling t.ParseFiles with the list of files matched by the
+// pattern.
+func ParseGlob(fs http.FileSystem, t *template.Template, pattern string) (*template.Template, error) {
+	filenames, err := vfspath.Glob(fs, pattern)
+	if err != nil {
+		return nil, err
+	}
+	if len(filenames) == 0 {
+		return nil, fmt.Errorf("vfs/text/vfstemplate: pattern matches no files: %#q", pattern)
+	}
+	return parseFiles(fs, t, filenames...)
+}
+
+// parseFiles is the helper for the method and function. If the argument
+// template is nil, it is created from the first file.
+func parseFiles(fs http.FileSystem, t *template.Template, filenames ...string) (*template.Template, error) {
+	if len(filenames) == 0 {
+		// Not really a problem, but be consistent.
+		return nil, fmt.Errorf("vfs/text/vfstemplate: no files named in call to ParseFiles")
+	}
+	for _, filename := range filenames {
+		b, err := vfsutil.ReadFile(fs, filename)
+		if err != nil {
+			return nil, err
+		}
+		s := string(b)
+		name := path.Base(filename)
+		// First template becomes return value if not already defined,
+		// and we use that one for subsequent New calls to associate
+		// all the templates together. Also, if this file has the same name
+		// as t, this file becomes the contents of t, so
+		//  t, err := New(name).Funcs(xxx).ParseFiles(name)
+		// works. Otherwise we create a new template associated with t.
+		var tmpl *template.Template
+		if t == nil {
+			t = template.New(name)
+		}
+		if name == t.Name() {
+			tmpl = t
+		} else {
+			tmpl = t.New(name)
+		}
+		_, err = tmpl.Parse(s)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return t, nil
+}


### PR DESCRIPTION
Your package `httpfs` is very helpful to me. Would it be possible to support `text/template`? That's just a copy of `httpfs/html/vfstemplate` with a few `html` replaced by `text`:

```
$ diff html/vfstemplate/vfstemplate.go text/vfstemplate/vfstemplate.go 
1c1
< // Package vfstemplate offers html/template helpers that use http.FileSystem.
---
> // Package vfstemplate offers text/template helpers that use http.FileSystem.
6d5
< 	"html/template"
8a8
> 	"text/template"
33c33
< 		return nil, fmt.Errorf("vfs/html/vfstemplate: pattern matches no files: %#q", pattern)
---
> 		return nil, fmt.Errorf("vfs/text/vfstemplate: pattern matches no files: %#q", pattern)
43c43
< 		return nil, fmt.Errorf("vfs/html/vfstemplate: no files named in call to ParseFiles")
---
> 		return nil, fmt.Errorf("vfs/text/vfstemplate: no files named in call to ParseFiles")
```