### PR TITLE
Added power support for the travis.yml file with ppc64le. and update go versions for package: httpfs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ arch:
   - amd64
   - ppc64le
 go:
-  - 1.x
+  - 1.13
+  - 1.14
+  - 1.15
   - master
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ arch:
   - amd64
   - ppc64le
 go:
-  - 1.13
-  - 1.14
-  - 1.15
+  - 1.x
   - master
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: go
+arch:
+  - amd64
+  - ppc64le
 go:
   - 1.x
   - master


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing.

updated the go version go:1.13, 1.14 and 1.15

